### PR TITLE
Bug Fixed

### DIFF
--- a/ApplyToTheIndustry/Assets/Scenes/MainGameScene.unity
+++ b/ApplyToTheIndustry/Assets/Scenes/MainGameScene.unity
@@ -2905,7 +2905,7 @@ PrefabInstance:
       objectReference: {fileID: 2046817732}
     - target: {fileID: 3255983354021394365, guid: ade798e1ca774494fbac59706cc05b05, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
-      value: ExitToDesktop
+      value: QuitGame
       objectReference: {fileID: 0}
     - target: {fileID: 3899718394328766712, guid: ade798e1ca774494fbac59706cc05b05, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target

--- a/ApplyToTheIndustry/Assets/Scripts/UI/NewsTicker.cs
+++ b/ApplyToTheIndustry/Assets/Scripts/UI/NewsTicker.cs
@@ -36,7 +36,6 @@ public class NewsTicker : MonoBehaviour
 
         newX = newX - (tickerSpeed * Time.deltaTime);
         childTransform.localPosition = new Vector3(newX, 0, 0);
-        Debug.Log(childTransform.localPosition);
         if (childTransform.localPosition.x < -6 * originalTickerHolderPosition.x)
         {
             childTransform.localPosition = originalTickerHolderPosition;

--- a/ApplyToTheIndustry/Assets/Scripts/UI/NewsTicker.cs
+++ b/ApplyToTheIndustry/Assets/Scripts/UI/NewsTicker.cs
@@ -20,7 +20,7 @@ public class NewsTicker : MonoBehaviour
 
     public void Awake()
     {
-        Debug.Log(tickerSpeed);
+
         LoadTicker();
         currentNewsDay = 0;
         TimeManager tmManager = ServiceLocator.Instance.GetService<TimeManager>();

--- a/ApplyToTheIndustry/Assets/Scripts/UI/NewsTicker.cs
+++ b/ApplyToTheIndustry/Assets/Scripts/UI/NewsTicker.cs
@@ -20,8 +20,9 @@ public class NewsTicker : MonoBehaviour
 
     public void Awake()
     {
-
+        Debug.Log(tickerSpeed);
         LoadTicker();
+        currentNewsDay = 0;
         TimeManager tmManager = ServiceLocator.Instance.GetService<TimeManager>();
         tmManager.D_timeout += LoadTicker;
         childTransform = tickerHolder.GetComponent<RectTransform>();
@@ -30,10 +31,12 @@ public class NewsTicker : MonoBehaviour
 
     public void Update()
     {
+
         float newX = childTransform.localPosition.x;
+
         newX = newX - (tickerSpeed * Time.deltaTime);
         childTransform.localPosition = new Vector3(newX, 0, 0);
-
+        Debug.Log(childTransform.localPosition);
         if (childTransform.localPosition.x < -6 * originalTickerHolderPosition.x)
         {
             childTransform.localPosition = originalTickerHolderPosition;
@@ -70,6 +73,12 @@ public class NewsTicker : MonoBehaviour
         textGameObject.GetComponent<RectTransform>().SetInsetAndSizeFromParentEdge(RectTransform.Edge.Left, 0, newWidth);
         textComponent.text = fullHeadline;
         currentNewsDay++;
+    }
+
+    private void OnDestroy()
+    {
+        TimeManager tmManager = ServiceLocator.Instance.GetService<TimeManager>();
+        tmManager.D_timeout -= LoadTicker;
     }
 
 }

--- a/ApplyToTheIndustry/Assets/Scripts/UI/PauseScreenBehavior.cs
+++ b/ApplyToTheIndustry/Assets/Scripts/UI/PauseScreenBehavior.cs
@@ -44,7 +44,12 @@ public class PauseScreenBehavior : MonoBehaviour
     public void BackToMainMenu()
     {
         // To do: Need to add some sort of reset functionality here
+        Time.timeScale = 1.0f;
+        SceneManager.LoadScene("IntroScene");
+    }
 
-        SceneManager.LoadScene("TitleScreen");
+    public void QuitGame()
+    {
+        Application.Quit();
     }
 }


### PR DESCRIPTION
<!---
Pull request template for 603 Game 3. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
News ticker was stopping its scroll across the screen when quitting to main menu and starting again. Investigation revealed this was caused by the pause screen stopping the time scale, which did not get reset when hitting entering back into play from the main menu. Added a change to the quit to menu function to address this. 

## Please describe how to test
Open the IntroScene, hit play, see the ticker running through the main screen. Hit Esc then quit to menu. Start game again and you'll see the ticker is now scrolling again.

## Relevant Screenshots
Hard to screen shot moving text. :/

## Issue worked on
#52 

## What Week of the 603 cycle is this due in?
Beta build
