### PR TITLE
Gray'd out buttons when player lacks resources

### DIFF
--- a/ApplyToTheIndustry/Assets/Scripts/GameResources/Action.cs
+++ b/ApplyToTheIndustry/Assets/Scripts/GameResources/Action.cs
@@ -19,11 +19,17 @@ public class Action : MonoBehaviour
 
     public void DoAction()
     {
-
+        // Check if cost is viable before doing action
         if(rm.IsCostViable(cost))
         {
             rm.ManageCost(cost);
         }
+
+        // Get the general UI manager
+        UIGeneralManager uiMngr = ServiceLocator.Instance.GetService<UIGeneralManager>();
+
+        // Update button usability
+        uiMngr.UpdateButtonUsability();
     }
 
     public void OpenInterface()

--- a/ApplyToTheIndustry/Assets/Scripts/GameResources/ResourceManager.cs
+++ b/ApplyToTheIndustry/Assets/Scripts/GameResources/ResourceManager.cs
@@ -66,12 +66,21 @@ public class ResourceManager : MonoBehaviour
 
     public void EndOfTheWeek()
     {
+        // Reset time resource and manager
+        _timeAvailable = maxTime;
+        _timeManager.ResetTimer();
+
+        // Update money with negation by weekly costs
         _moneyAvailable.value -= weeklyCosts;
         moneyUI.UpdateMoneyText(_moneyAvailable.value);
 
+        // Get general UI manager and update button usability
+        UIGeneralManager uiMngr = ServiceLocator.Instance.GetService<UIGeneralManager>();
+        uiMngr.UpdateButtonUsability();
+
         // Trigger the game over screen as soon as 
         // the player runs out of money
-        if(_moneyAvailable.value <= 0.0f)
+        if (_moneyAvailable.value <= 0.0f)
         {
             ServiceLocator.Instance.GetService<UIGeneralManager>().MoveToGameOverScreen();
         }

--- a/ApplyToTheIndustry/Assets/Scripts/UI/UIGeneralManager.cs
+++ b/ApplyToTheIndustry/Assets/Scripts/UI/UIGeneralManager.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
 
 public class UIGeneralManager : MonoBehaviour
 {
@@ -13,6 +14,7 @@ public class UIGeneralManager : MonoBehaviour
     private void Start()
     {
         ServiceLocator.Instance.GetService<TimeManager>().D_timeout += MoveToFeedbackScreen;
+        UpdateButtonUsability();
     }
     public void MoveToFeedbackScreen()
     {
@@ -77,6 +79,26 @@ public class UIGeneralManager : MonoBehaviour
             JobManager jobMngr = ServiceLocator.Instance.GetService<JobManager>();
             if (!jobMngr.playerWastedTime)
                 hiddenPanel.DisableObject();
+        }
+    }
+
+    public void UpdateButtonUsability()
+    {
+        // Get the resource manager
+        ResourceManager rsrcMngr = ServiceLocator.Instance.GetService<ResourceManager>();
+
+        // Iterate through timer panel buttons
+        foreach(Action action in timerPanel.GetComponentsInChildren<Action>())
+        {
+            // Get game object's button component
+            Button btn = action.gameObject.GetComponent<Button>();
+
+            // Check if player can use buttons
+            // and disable interactions if they cant
+            if (rsrcMngr.IsCostViable(action.cost))
+                btn.interactable = true;
+            else
+                btn.interactable = false;
         }
     }
 


### PR DESCRIPTION
<!---
Pull request template for 603 Game 3. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
- Made buttons gray out when player lacks sufficient resources to use them
- Fixed timer bug 

## Please describe how to test
Play through game as normal, when you run low on resources certain buttons will go gray and wont be clickable.

## Relevant Screenshots
![image](https://github.com/amonjerro/applyToTheIndustrySim/assets/26527955/8f19a942-04c7-46f8-a5ad-221c927137e1)

## Issue worked on
https://github.com/amonjerro/applyToTheIndustrySim/issues/56 https://github.com/amonjerro/applyToTheIndustrySim/issues/73

## What Week of the 603 cycle is this due in?
Week 2, beta submission
