### PR TITLE
Rotating news tickers

### DIFF
--- a/ApplyToTheIndustry/Assets/Scripts/UI/NewsTicker.cs
+++ b/ApplyToTheIndustry/Assets/Scripts/UI/NewsTicker.cs
@@ -57,7 +57,7 @@ public class NewsTicker : MonoBehaviour
 
         if (currentNewsDay >= news.Count)
         {
-            return;
+            currentNewsDay = 0;
         }
         // Load the current active object;
         _activeObject = news[currentNewsDay];


### PR DESCRIPTION
<!---
Pull request template for 603 Game 3. Feel free to remove comments as you fill out information.
--->
## Summarize what is being added
News ticker should return to 0 index once it exceeds the total news cycle. Artistic statement behind this is that this industry is also laden with stories we see over and over again.

## Please describe how to test
Pass the days, you should see the news ticker beneath the screen eventually start repeating headlines.

## Relevant Screenshots
<!---Paste in some screenshots to help reduce need of excess testing. If screenshots are not relevant here, then remove this section--->

## Issue worked on
This is its own issue.

## What Week of the 603 cycle is this due in?
Playtest
